### PR TITLE
Bastion instabreak fix

### DIFF
--- a/Bastion/src/isaac/bastion/BastionBlock.java
+++ b/Bastion/src/isaac/bastion/BastionBlock.java
@@ -186,15 +186,21 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock>
 	}
 
 
+	/**
+	 * @brief Gets the percentage of the reinforcement that should erode from the block
+	 * @return The percentage that should erode
+	 */
 	public double erosionFromBlock(){
 		double scaleStart=Bastion.getConfigManager().getBastionBlockScaleFacStart();
 		double scaleEnd=Bastion.getConfigManager().getBastionBlockScaleFacEnd();
-		int time=(int) (System.currentTimeMillis()-placed);
+		
+		// This needs to be a long or it will roll over after 21 days!
+		long time = System.currentTimeMillis() - placed;
 
-		if(SCALING_TIME==0){
+		if(SCALING_TIME == 0){
 			return scaleStart;
-		} else if(time<SCALING_TIME){
-			return (((scaleEnd-scaleStart)/(float)SCALING_TIME)*time+scaleStart);
+		} else if(time < SCALING_TIME){
+			return (((scaleEnd - scaleStart) / (float)SCALING_TIME) * time + scaleStart);
 		} else{
 			return scaleEnd;
 		}


### PR DESCRIPTION
Compare time delta as a long instead of int.
The time delta was getting calculated as an int, which can only hold 21 days worth of milliseconds. After 21 days the number was rolling over.