### PR TITLE
Now checks both when a pearl launchs and when it lands if it is in a field.

### DIFF
--- a/Bastion/src/isaac/bastion/listeners/EnderPearlListener.java
+++ b/Bastion/src/isaac/bastion/listeners/EnderPearlListener.java
@@ -36,6 +36,7 @@ public class EnderPearlListener implements Listener {
 		if(event.isCancelled())
 			return;
 		if(event.getEntity() instanceof EnderPearl) {
+			manager.handleEnderPearlLaunched(event);
 			EnderPearl pearl=(EnderPearl) event.getEntity();
 			pearlMang.handlePearlLaunched(pearl);
 		}

--- a/Bastion/src/isaac/bastion/manager/EnderPearlManager.java
+++ b/Bastion/src/isaac/bastion/manager/EnderPearlManager.java
@@ -71,8 +71,8 @@ public class EnderPearlManager {
 		
 		
 		Player threw=null;
-		if(pearl.getShooter() instanceof Player){
-			threw=(Player) pearl.getShooter();
+		if(pearl.getShooter() instanceof Player) { //not sure why getShooter is showing up
+			threw = (Player) pearl.getShooter();
 		}
 
 		Set<BastionBlock> possible = bastions.getPossibleTeleportBlocking(pearl.getLocation(), maxDistance); //all the bastion blocks within range of the pearl
@@ -404,7 +404,7 @@ public class EnderPearlManager {
 	}
 	
 	private void handleTeleport(BastionBlock blocking ,Location loc, Player player){
-		if (!Bastion.getBastionManager().onCooldown(player.getName())) blocking.erode(blocking.erosionFromPearl());
+		if (!Bastion.getBastionManager().onCooldown(player)) blocking.erode(blocking.erosionFromPearl());
 		
 		player.sendMessage(ChatColor.RED+"Ender pearl blocked by Bastion Block");
 		player.getInventory().addItem(new ItemStack(Material.ENDER_PEARL));


### PR DESCRIPTION
Also changes some stuff to use UUIDs. The check on landing can probably be removed or at least modified to not include a check of where the player teleported from, but I've not gotten around to it yet. In other news it occurs to me I can block cart elevators inside the field by non-members. Is it worth doing?